### PR TITLE
Small stuff in prep for exhaustive run on large storage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ db: libs
 
 tidy:
 	# removing trailing whitespace
-	sed -i -e 's/[ \t]$$//' *.h *.c
+	sed -i -e 's/[ \t]*$$//' *.h *.c
 
 clean:
 	rm -rf bpt db bfcf *.gc *.o bin/*.o

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ all: libs db
 db: libs
 	${CMD} bin/utils.o bin/board.o bin/bplustree.o db_utils.c -o db
 
+tidy:
+	# removing trailing whitespace
+	sed -i -e 's/[ \t]$$//' *.h *.c
 
 clean:
 	rm -rf bpt db bfcf *.gc *.o bin/*.o

--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -3,13 +3,27 @@ else
 	MODEFLAG=-D${MODE}
 endif
 
+ifeq (${ARCH},32)
+	ARCHFLAGS=-m32 -DBUILD_32_BITS
+else
+endif
+
+
 CC=gcc
-DONTCARE_WARNINGS= -Wno-padded -Wno-format-nonliteral
-CFLAGS=-std=c99 -g -Wall -Wextra -pedantic ${DONTCARE_WARNINGS} -O3 ${MODEFLAG}
+ifeq (${MODE},NDEBUG)
+MODE_OK_WARNINGS= -Wno-unused-parameter -Wno-unused-variable \
+	-Wno-unused-but-set-variable
+else
+MODE_OK_WARNINGS= -Wno-unused-parameter
+endif
+
+DONTCARE_WARNINGS= -Wno-padded -Wno-format-nonliteral ${MODE_OK_WARNINGS}
+CFLAGS=-std=c99 -g -Wall -Wextra -pedantic -Werror ${DONTCARE_WARNINGS} -O3 ${MODEFLAG} ${ARCHFLAGS}
 CMD=${CC} ${CFLAGS}
 
 all: libs db
 	${CMD} bin/utils.o bin/bplustree.o bin/board.o bpt_test.c -o bpt
+	${CMD} bin/utils.o bin/counter.o bin/board.o bin/bplustree.o store_boards.c -o store_boards
 	${CMD} bin/utils.o bin/counter.o bin/board.o bin/bplustree.o bruteforce_connect_four.c -o bfcf
 
 db: libs
@@ -17,7 +31,7 @@ db: libs
 
 tidy:
 	# removing trailing whitespace
-	sed -i -e 's/[ \t]$$//' *.h *.c
+	sed -i -e 's/[ \t]*$$//' *.h *.c
 
 clean:
 	rm -rf bpt db bfcf *.gc *.o bin/*.o

--- a/Makefile.gcc
+++ b/Makefile.gcc
@@ -15,6 +15,9 @@ all: libs db
 db: libs
 	${CMD} bin/utils.o bin/board.o bin/bplustree.o db_utils.c -o db
 
+tidy:
+	# removing trailing whitespace
+	sed -i -e 's/[ \t]$$//' *.h *.c
 
 clean:
 	rm -rf bpt db bfcf *.gc *.o bin/*.o

--- a/base.h
+++ b/base.h
@@ -61,9 +61,9 @@ sprintf(_verbose_buf, "%s(): " #format, __func__, __VA_ARGS__ ); \
 } while (0)
 
 #else
-	
+
 #define print( format, ... ) // DEBUG OFF
-	
+
 #define prints( string ) // DEBUG OFF
 
 #endif

--- a/board.c
+++ b/board.c
@@ -17,23 +17,23 @@ char states[4] = {' ', 'O', 'X', '@'}; // empty, white, black, unused | 00, 01, 
 winline winlines[NUM_WINLINES] = {
 
 	// 6x4 horizontal = 24
-	WINLINE_HOZ(0) 
-	WINLINE_HOZ(1) 
-	WINLINE_HOZ(2) 
-	WINLINE_HOZ(3) 
-	WINLINE_HOZ(4) 
-	WINLINE_HOZ(5) 
-	
-	// 7x3 vertical = 21
-	WINLINE_VERT(0) 
-	WINLINE_VERT(1) 
-	WINLINE_VERT(2) 
-	WINLINE_VERT(3) 
-	WINLINE_VERT(4) 
-	WINLINE_VERT(5) 
-	WINLINE_VERT(6) 
+	WINLINE_HOZ(0)
+	WINLINE_HOZ(1)
+	WINLINE_HOZ(2)
+	WINLINE_HOZ(3)
+	WINLINE_HOZ(4)
+	WINLINE_HOZ(5)
 
-	// 3x4 diagonal = 12 
+	// 7x3 vertical = 21
+	WINLINE_VERT(0)
+	WINLINE_VERT(1)
+	WINLINE_VERT(2)
+	WINLINE_VERT(3)
+	WINLINE_VERT(4)
+	WINLINE_VERT(5)
+	WINLINE_VERT(6)
+
+	// 3x4 diagonal = 12
 	// starting bottom left, sweeping right
 	WINLINE_DIAG_UP(0,5)
 	// starting bottom left -1y, sweeping right
@@ -101,9 +101,9 @@ uint8 s2w[42][14] = {
 };
 
 void map_squares_to_winlines() {
-	
+
 	printf("uint s3w[42][14] = {\n");
-	
+
 	uint8 temp[13];
 	uint8 wi = 0;
 	for( uint8 i=0; i<42; i++ ) {
@@ -125,24 +125,24 @@ void map_squares_to_winlines() {
 		}
 		printf("},\n");
 	}
-	
+
 	printf("};\n");
 }
 
 
 
 void print_winline( int i ) {
-	printf("Winline[%02d] = [%d,%d]-[%d,%d]-[%d,%d]-[%d,%d]\n", i 
-		, winlines[i].x[0], winlines[i].y[0] 
-		, winlines[i].x[1], winlines[i].y[1] 
-		, winlines[i].x[2], winlines[i].y[2] 
-		, winlines[i].x[3], winlines[i].y[3]	
+	printf("Winline[%02d] = [%d,%d]-[%d,%d]-[%d,%d]-[%d,%d]\n", i
+		, winlines[i].x[0], winlines[i].y[0]
+		, winlines[i].x[1], winlines[i].y[1]
+		, winlines[i].x[2], winlines[i].y[2]
+		, winlines[i].x[3], winlines[i].y[3]
 	);
-	
+
 }
 
 void dump_winlines() {
-	
+
 	for(int i=0; i<69; i++ ) {
 		print_winline( i );
 	}
@@ -191,7 +191,7 @@ void print_winlines(wins* w) {
 			print_winline( i );
 		}
 	}
-	
+
 }
 
 wins* new_winbits() {
@@ -207,7 +207,7 @@ wins* new_winbits() {
 	}
 	out->white[8] = 0x1f; // exclude top 3 bits
 	out->black[8] = 0x1f;
-	
+
 	return out;
 }
 
@@ -220,13 +220,13 @@ board* new_board() {
 	}
 //	printf("Create board %p\n", b);
 	memset( b->squares, 0, ROWS*COLS );
-	
+
 	b->winlines = new_winbits();
 //	printf("Create winlines: %p\n", b->winlines);
-	
+
 	b->state = 0;
 	b->state |= WHITE;
-	
+
 	return b;
 }
 
@@ -234,21 +234,21 @@ void free_board( board* b ) {
 
 	if( b->winlines != NULL ) {
 //		printf("Free winlines: %p\n", b->winlines);
-		free( b->winlines );	
-		b->winlines = NULL;	
+		free( b->winlines );
+		b->winlines = NULL;
 	}
 //	printf("Free board: %p\n", b);
 	free( b );
-	
+
 	b = NULL;
 }
 
 board* copy_board( board* src ) {
-	
+
 	board* dest = (board*) malloc( sizeof(board) );
 //	printf("Copy board dest %p, src %p\n", dest, src);
 	memcpy( dest->squares, src->squares, ROWS*COLS );
-	
+
 	if( src->winlines != NULL ) {
 		dest->winlines = (wins*)malloc( sizeof(wins) );
 		if( dest->winlines == NULL ) {
@@ -259,9 +259,9 @@ board* copy_board( board* src ) {
 //		printf("Copy winlines dest %p, src %p\n", dest->winlines, src->winlines);
 		memcpy( dest->winlines, src->winlines, sizeof(wins) );
 	}
-	
+
 	dest->state = src->state;
-	
+
 	return dest;
 }
 
@@ -274,34 +274,34 @@ void pass_turn( board* b ) {
 		b->state &= ~BLACK;
 		b->state |= WHITE;
 	}
-	
+
 }
 
 unsigned char current_player( board* b ) {
-	
+
 	return b->state & WHITE ? WHITE : BLACK;
 }
 
 internal void update_winlines( board* b, int move_y, int move_x ) {
-	
+
 	player current = current_player( b );
 //	print("Updating winlines after move by %s on [%d,%d]", current == WHITE ? "White" : "Black", move_x, move_y);
 //	print_winbits( b->winlines->white );
 //	print_winbits( b->winlines->black );
-	
+
 	int square_index = COLS*move_y + move_x;
 //	printf("Square [%d,%d] = %d\n", move_x, move_y, square_index);
 //	printf("num winlines: %d\n", s2w[square_index][0]);
-	
+
 	unsigned char* winline = current == WHITE ? b->winlines->black : b->winlines->white;
-	
+
 	for( unsigned int w=1; w<=s2w[square_index][0]; w++ ) {
 		unsigned int winline_index = s2w[square_index][w];
 
 		// clear it for opponent
 		int bit_to_turn_off = 1 << (winline_index % 8);
 //		printf("Turn off bit %d of byte %d\n", (winline_index % 8), winline_index/8);
-		
+
 		// I'm sure we can do this more elegantly, but I've had a few pints and I'm the train and this works.
 		unsigned char old_state = winline[winline_index/8];
 		int new_stuff = ~bit_to_turn_off;
@@ -327,12 +327,12 @@ internal void update_winlines( board* b, int move_y, int move_x ) {
 			char scratch[200];
 			sprintf( scratch, "%s wins on line %d", current == WHITE ? "White" : "Black", winline_index );
 			render( b, scratch, false );
-#endif			
+#endif
 			b->state |= OVER;
 		}
 	}
 
-	
+
 
 //	print_winlines( b->winlines );
 }
@@ -342,12 +342,12 @@ internal void update_winlines( board* b, int move_y, int move_x ) {
 
 
 board* drop( board* src, int x ) {
-	
+
 	assert( !is_over( src ) );
-	
+
 	assert( x >= 0 );
 	assert( x < COLS );
-	
+
 	// check if any room left
 	int y_index = -1;
 	for( int y=ROWS-1; y>=0; y-- ) { // seek down along column until we can hit occupied
@@ -358,11 +358,11 @@ board* drop( board* src, int x ) {
 			break;
 		}
 	}
-	
+
 	if( y_index == -1 ) {
 		return NULL;
 	}
-	
+
 	board* dest = copy_board( src );
 	dest->squares[x][y_index] = current_player( src );
 
@@ -377,14 +377,14 @@ board* drop( board* src, int x ) {
 }
 
 internal uint8 check_state_after_move( board* b, uint8 move_y, uint8 move_x, uint8 player ) {
-	
+
 	assert( move_y < ROWS );
 	assert( move_x < COLS );
 
 	uint8 state = 0;
-	
+
 	uint8 square_index = COLS*move_y + move_x;
-	
+
 	for( uint8 w=1; w<=s2w[square_index][0]; w++ ) {
 		uint8 winline_index = s2w[square_index][w];
 
@@ -413,22 +413,22 @@ internal uint8 check_state_after_move( board* b, uint8 move_y, uint8 move_x, uin
 			return state;
 		}
 	}
-	
+
 	// it's a draw if every top of the column is not empty
 	// easier: it is NOT a draw (i.e. it is an ongoing game) if there is at least one colum that has an open space
 	for( uint8 x=0; x<COLS; x++ ) {
-		if( b->squares[x][ROWS-1] == EMPTY ){ 
+		if( b->squares[x][ROWS-1] == EMPTY ){
 			return state;
 		}
 	}
-	
+
 	// not a win, not ongoing => DRAW
 	state |= DRAW;
 	return state;
 }
 
 uint8 multidrop( board* src, board63* next_boards ) {
-	
+
 	assert( !is_over( src ) );
 
 	// check if if we can drop in a column for all columns
@@ -436,7 +436,7 @@ uint8 multidrop( board* src, board63* next_boards ) {
 	uint8 player = current_player( src );
 	for( uint8 x_index=0; x_index<COLS; x_index++ ) {
 		uint8 y_index = ROWS; // set to the invalid value of ROWS
-		
+
 		// TODO(performance): maybe seeking down will be less work as in later generations there are more spots filled?
 		for( uint8 y=0; y < ROWS; y++ ) { // seek up along column until we hit an empty
 			if( src->squares[x_index][y] == EMPTY ) {
@@ -452,7 +452,7 @@ uint8 multidrop( board* src, board63* next_boards ) {
 			// encode the board (this just retains the set locations plus the gameover bit)
 			// TODO(performance): why do we encode/decode? maybe just have 7 board* preallocated we just overwrite?
 			next_boards[succesful_drops] = encode_board( src );
-			if( new_state & OVER ) {	
+			if( new_state & OVER ) {
 				next_boards[succesful_drops] |= 1; // set win bit
 			}
 
@@ -460,7 +460,7 @@ uint8 multidrop( board* src, board63* next_boards ) {
 			src->squares[x_index][y_index] = EMPTY;
 			succesful_drops++;
 		}
-		
+
 	}
 
 	return succesful_drops;
@@ -472,36 +472,36 @@ int is_over( board* b ) {
 }
 
 void render( board* b, const char* text, int show_winlines ) {
-	
+
 	printf( "Board: %s\n(player turn: %s, State: %d)\n", text, current_player(b) == WHITE ? "White" : "Black", b->state );
-	
+
 	for( int y=ROWS-1; y>=0; y-- ) {
 		printf("--+---+---+---+---+---+---+---+\n");
 		printf("%d ", y);
 		for( int x=0; x<COLS; x++) {
-			
+
 			unsigned char c = b->squares[x][y];
 //			printf("\nstate: %x\n", c);
 			// LSB 2 bits are now our value
-			//printf("Square value: %x\n", c); 
+			//printf("Square value: %x\n", c);
 			printf("| %c ", states[c]);
 		}
 		printf("|\n");
 	}
 	printf("--+---+---+---+---+---+---+---+\n");
 	printf("  | 0 | 1 | 2 | 3 | 4 | 5 | 6 |\n");
-	
+
 	if( show_winlines && !is_over( b ) ) {
 		print_winlines( b->winlines );
 	}
 }
 
 void read_board_record_from_buf( board63 b63, char* buf, off_t pos, board* b ) {
-	
+
 	decode_board63( b63, b );
 
 	// read state
-	b->state = (uint8)buf[ pos ];	
+	b->state = (uint8)buf[ pos ];
 
 	b->winlines = new_winbits();
 
@@ -513,7 +513,7 @@ void read_board_record_from_buf( board63 b63, char* buf, off_t pos, board* b ) {
 
 
 void write_board_record( board* b, FILE* out ) {
-	
+
 	// write gamestate
 	fwrite( &b->state, sizeof(b->state), 1, out );
 
@@ -521,8 +521,8 @@ void write_board_record( board* b, FILE* out ) {
 	if( elements_written != 2 ) {
 		perror("fwrite()");
 		exit( EXIT_FAILURE );
-	}		
-	
+	}
+
 }
 
 // TODO(cleanup): This can go
@@ -532,17 +532,17 @@ void write_board( char* filename, board* b ) {
 	FOPEN_CHECK( out, filename, "wb" );
 
 	write_board_record( b, out );
-	
+
 	fclose( out );
-	
+
 }
 
 player is_win_for( board* b, player p ) {
-	
+
 	if( b->state & OVER ) {
 		return (b->state & p) ? 1 : 0;
-	} 
-	
+	}
+
 	return 0;
 }
 

--- a/board.h
+++ b/board.h
@@ -38,11 +38,11 @@ typedef unsigned long board63;
 
 // TODO(confusion): two names is maybe confusing
 #define ENCODED_BOARD_SIZE (sizeof(board63))
-		
+
 // bit fields for winlineIDs for White/Black
 // winlineID 0 is byte 0, LSB 0
 // winlineID 69 is byte 8 (69/8=8) LSB 5 (69%8=5)
-// this means bits 8,7,6 of byte 8 are unused 
+// this means bits 8,7,6 of byte 8 are unused
 // byte 0          1
 // 7,6,5,4,3,2,1,0 14,13,12,11,10,9,8
 typedef struct wins {
@@ -93,7 +93,7 @@ typedef struct board {
 											{ {x+2,x+3,x+4,x+5}, {y+0,y+1,y+2,y+3} }, \
 											{ {x+3,x+4,x+5,x+6}, {y+0,y+1,y+2,y+3} },
 
-			
+
 
 extern winline winlines[NUM_WINLINES];
 extern char states[4];
@@ -123,7 +123,7 @@ void pass_turn( board* b );
 
 void render( board* b, const char* text, int show_winlines );
 
-unsigned char current_player( board* b );	
+unsigned char current_player( board* b );
 unsigned char is_win_for( board* b, unsigned char player );
 unsigned char is_draw( board* b );
 int is_over( board* b );

--- a/board63.c
+++ b/board63.c
@@ -10,7 +10,7 @@ void print_board63( board63 b ) {
 		printf("%c", (b >> i) & 1 ? '1' : '0' );
 	}
 	printf("\ncnt 0=w 1=b");
-	
+
 	char out[7*(3+1+6+1)+1+1+1]; // = 80
 	memset( out, 'x', 80);
 	int offset = 0; // since we're inserting ':' and '\n'
@@ -25,17 +25,17 @@ void print_board63( board63 b ) {
 		}
 		out[offset+i] = ((b >> (63-i)) & 1) ? '1' : '0'; // there are 63 bits, but the last one is unused out of 64
 	}
-	
-	out[offset+63+0] = '\n';	
+
+	out[offset+63+0] = '\n';
 	out[offset+63+1] = '0' + (b & 0x1);
 	out[offset+63+2] = '\0';
 	printf("%s\n", out);
 }
 
 board63 encode_board( board* src ) {
-	
+
 	board63 dest = 0;
-	
+
 	// encode every column as fillcount + 6 bits
 	// MSB(3) = fillcount of col0 etc for easy binary reading of humans
 	unsigned char pieces = 0;
@@ -58,21 +58,21 @@ board63 encode_board( board* src ) {
 		dest |= temp;
 		// reset
 		pieces = 0;
-		
-		
+
+
 	}
-	
+
 	dest <<= 1; // last bit is state
-	
+
 	if( src->state & OVER ) {
 		dest |= 1; // set the gameover bit
 	}
-	
+
 	return dest;
 }
 
 void decode_board63( board63 src, board* dest ) {
-	
+
 	dest->state = 0;
 	dest->winlines = NULL;
 
@@ -83,7 +83,7 @@ void decode_board63( board63 src, board* dest ) {
 		dest->state |= OVER;
 	}
 	src >>= 1; // skip it
-	
+
 	// fill it backwards
 	int total_pieces = 0;
 	for( int datacol=COLS-1; datacol>=0; datacol-- ) {
@@ -99,7 +99,7 @@ void decode_board63( board63 src, board* dest ) {
 	}
 
 	if( total_pieces % 2 == 0 ) {
-		dest->state |= WHITE;		
+		dest->state |= WHITE;
 	} else {
 		dest->state |= BLACK;
 	}

--- a/bplustree.c
+++ b/bplustree.c
@@ -525,7 +525,7 @@ node* new_node( database* db ) {
 void print_database_stats( database* db ) {
 
 	double cache_memory_used = (double)(CACHE_SIZE * ( sizeof(node) + sizeof(entry*) + sizeof(entry) + sizeof(free_entry) ) ) / (double)megabyte(1);
-	printf("BPT ORDER: %d, Node size: %lu bytes, CACHE_SIZE: %lu (Cache max mem use: %.2f MB)\n", ORDER, sizeof(node), CACHE_SIZE, cache_memory_used);
+	printf("BPT ORDER: %d, Node size: %zu bytes, CACHE_SIZE: %zu (Cache max mem use: %.2f MB)\n", ORDER, sizeof(node), CACHE_SIZE, cache_memory_used);
 
 	cache_stats stats = get_database_cache_stats( db );
 	printf("Total cache hits: %llu\n", (unsigned long long)stats.hits);

--- a/bplustree.c
+++ b/bplustree.c
@@ -1,6 +1,17 @@
 #ifdef __linux
 	// in order to fileno() we need a non-C99 feature
-	#define _POSIX_SOURCE 200112L
+	// The fileno() function is widely supported and is in POSIX from 2001:
+	// http://pubs.opengroup.org/onlinepubs/009604599/functions/fileno.html
+	// To satisfy the fileno() Feature Test Macro Requirements, as can
+	// be found in the fileno() man(3) page for the LibC in use, e.g.:
+	// https://manpages.debian.org/stretch/manpages-dev/fileno.3.en.html
+	// we ensure that _POSIX_C_SOURCE is defined, as required by:
+	// http://pubs.opengroup.org/onlinepubs/009604599/basedefs/xbd_chap02.html#tag_02_02_01
+	// We gaurd against redefining it, as it may be larger, e.g.: 200809L:
+	// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap02.html#tag_02_02_01
+	#ifndef _POSIX_C_SOURCE
+	#define _POSIX_C_SOURCE 200112L
+	#endif
 #endif
 
 #include <assert.h>

--- a/bplustree.c
+++ b/bplustree.c
@@ -574,7 +574,7 @@ void bpt_insert_node( database* db, node* n, board63 up_key, uint32 node_to_inse
 	assert( n->id != 0 );
 	check_tree_correctness( db, n );
 
-	uint32 insert_location;
+	uint32 insert_location = 0;
 	int bsearch_result = binary_search( n->keys, n->num_keys, up_key, &insert_location );
 	assert( bsearch_result == BINSEARCH_FOUND || bsearch_result == BINSEARCH_INSERT );
 	print("insert key 0x%lx at position %u, node at position %u", up_key, insert_location, insert_location+1);
@@ -890,7 +890,7 @@ internal node* bpt_find_node( database* db, node* root, board63 key ) {
 
 		print("checking node %u", current->id);
 
-		uint32 node_index;
+		uint32 node_index = 0;
 		switch( binary_search( current->keys, current->num_keys, key, &node_index) ) {
 			case BINSEARCH_FOUND:
 				node_index++; // if we hit the key, the correct node is to the right of that key

--- a/bplustree.c
+++ b/bplustree.c
@@ -34,7 +34,7 @@ internal void write_database_header( database* db );
 cache_stats get_database_cache_stats( database* db ) {
 
 	db->cstats.hit_ratio = (double)db->cstats.hits / (double)(db->cstats.hits + db->cstats.misses);
-	
+
 	return db->cstats;
 }
 /************** stuff that deals with the fact we store things on disk ********************/
@@ -42,16 +42,16 @@ cache_stats get_database_cache_stats( database* db ) {
 
 // the initial node is 1 (0 is reserved)
 off_t file_offset_from_node( size_t id ) {
-	
+
 	assert( id != 0 );
 	off_t offset = sizeof(database_header);
 	offset += ((id-1) * sizeof(node));
 	return offset;
-	
+
 }
 
 off_t file_offset_from_row_index( size_t row_index ) {
-	
+
 	return (off_t)row_index * (off_t)BOARD_SERIALIZATION_NUM_BYTES;
 }
 
@@ -63,10 +63,10 @@ void database_store_node( database* db, node* n ) {
 	}
 
 	counters.node_writes++;
-	
+
 	// append_log( db, "database_store_node(): writing node %lu (parent %lu) to %s\n", n->id, n->parent_node_id, db->index_filename );
 	print("writing node %u (leaf: %s) (parent %u) to %s", n->id, n->is_leaf ? "true" : "false",  n->parent_node_id, db->index_filename );
-	
+
 	off_t offset = file_offset_from_node( n->id );
 	size_t node_block_bytes = sizeof( node );
 
@@ -75,9 +75,9 @@ void database_store_node( database* db, node* n ) {
 		perror("fseek()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	print("storing %lu bytes at offset %llu", node_block_bytes, offset );
-	
+
 	n->is_dirty = false;
 
 	size_t written = fwrite( n, node_block_bytes, 1, db->index_file );
@@ -102,20 +102,20 @@ void write_database_header( database* db ) {
 		perror("frwite()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 }
 
 void read_database_header( database* db ) {
-	
+
 	database_header* header = (database_header*) malloc( sizeof(database_header) );
 	size_t objects_read = fread( header, sizeof(database_header), 1, db->index_file );
 	if( objects_read != 1 ) {
 		perror("fread()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	db->header = header;
-	
+
 }
 
 void database_set_filenames( database* db, const char* name ) {
@@ -129,7 +129,7 @@ void database_set_filenames( database* db, const char* name ) {
 }
 
 void database_open_files( database* db ) {
-	
+
 	// we read write to the index: new nodes are appended, but also rewritten when changed
 	FOPEN_CHECK( db->index_file, db->index_filename, "r+" );
 	print("opened index file %s", db->index_filename);
@@ -151,29 +151,29 @@ void database_open_files( database* db ) {
 
 node* node_get_mem() {
 	node* result;
-	
+
 	result = (node*) malloc( sizeof(node) );
 	assert( result != NULL );
 	counters.mallocs++;
-	
+
 	return result;
 }
 
 void database_mem_pool_init( database* db ) {
-	
-	
+
+
 	print("Reserving space for nodes: %lu bytes", CACHE_MEM_LIMIT );
 
 }
 
 void database_setup_cache( database* db ) {
-	
+
 	db->node_cache = (cache*) malloc( sizeof(cache) );
 	// TODO(correctness): not sure if this needs to be explicitly zero'd or maybe calloc?
 	memset( db->node_cache->buckets, 0, sizeof(db->node_cache->buckets) );
 	db->node_cache->num_stored = 0;
 	db->node_cache->free_list = NULL;
-	
+
 }
 
 void database_create( const char* name ) {
@@ -183,9 +183,9 @@ void database_create( const char* name ) {
 		perror("malloc()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	db->name = name;
-	
+
 	database_set_filenames( db, name );
 	// create the index file
 	create_empty_file( db->index_filename );
@@ -206,10 +206,10 @@ void database_create( const char* name ) {
 	clear_cache( db, db->node_cache );
 	prints("free cache");
 	free( db->node_cache );
-	
+
 	write_database_header( db );
 	free( db->header );
-	
+
 	fclose( db->index_file );
 
 	free( db );
@@ -219,20 +219,20 @@ void database_create( const char* name ) {
 
 database* database_open( const char* name, uint8 mode ) {
 
-	
+
 	database* db = (database*) malloc( sizeof(database) );
 	if( db == NULL ) {
 		perror("malloc()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	db->name = name;
-	
+
 	database_set_filenames( db, name );
 
 	// we are opening a file presumably for reading the rows table, and maybe writing
 	database_open_files( db );
-	
+
 	// read the root node, node_count and row_count
 	read_database_header( db );
 	print("nodes: %u, rows: %llu, root node ID: %u", db->header->node_count, db->header->table_row_count, db->header->root_node_id );
@@ -240,21 +240,21 @@ database* database_open( const char* name, uint8 mode ) {
 	database_mem_pool_init( db );
 
 	database_setup_cache( db );
-	
-	return db;	
+
+	return db;
 }
 
 void database_close( database* db ) {
-	
+
 	print("closing %s", db->name );
-	
+
 	write_database_header( db );
-	
+
 	clear_cache( db, db->node_cache );
 	free( db->node_cache );
-	
+
 	free( db->header );
-	
+
 	fclose( db->index_file );
 
 	print("closed %s", db->name);
@@ -266,7 +266,7 @@ void database_close( database* db ) {
 	(order is random!)
 */
 void database_init_cursor( database* db, database_cursor* cursor ) {
-	
+
 	print("Creating a cursor for database '%s'", db->name);
 	cursor->db = db;
 	cursor->num_records = db->header->table_row_count;
@@ -287,7 +287,7 @@ void database_init_cursor( database* db, database_cursor* cursor ) {
 	cursor->index_file_size = index_file_stat.st_size;
 	cursor->data = (uint64*)mmap( NULL, (size_t)cursor->index_file_size, PROT_READ, MAP_PRIVATE, fileno(cursor->db->index_file), 0 );
 	if( cursor->data == MAP_FAILED ) {
-		perror("mmap()");	
+		perror("mmap()");
 	}
 
 	// index into the memmap
@@ -298,7 +298,7 @@ void database_init_cursor( database* db, database_cursor* cursor ) {
 }
 
 void database_dispose_cursor( database_cursor* cursor ) {
-	
+
 	print("Disposing cursor for database '%s'", cursor->db->name );
 	if( cursor->data != NULL ) {
 		munmap( cursor->data, (size_t)cursor->index_file_size );
@@ -309,7 +309,7 @@ void database_dispose_cursor( database_cursor* cursor ) {
 }
 
 board63 database_get_record( database_cursor* cursor ) {
-	
+
 	print("Node %u: record %u/%u", cursor->current_node->id, cursor->current_in_node, cursor->current_node->num_keys);
 	while( !cursor->current_node->is_leaf || cursor->current_in_node >= cursor->current_node->num_keys ) {
 		print("Node %u is not a leaf or done, loading node %u", cursor->current_node_id, cursor->current_node_id + 1);
@@ -320,15 +320,15 @@ board63 database_get_record( database_cursor* cursor ) {
 		print("Moved to node %u, keys: %u", cursor->current_node->id, cursor->current_node->num_keys );
 		assert( cursor->current_node_id <= cursor->node_count );
 	}
-	
+
 	cursor->current++;
-	
+
 	return cursor->current_node->keys[cursor->current_in_node++];
 }
 
 // This is more like store_in_index or something
 bool database_put( database* db, board63 key ) {
-	
+
 	print("key for this board: 0x%lx", key );
 	record r = { .key = key, .value.board_data = 0xdeadbeef };
 	print("loading root node ID %u", db->header->root_node_id );
@@ -337,7 +337,7 @@ bool database_put( database* db, board63 key ) {
 	bool inserted = bpt_insert_or_update( db, root_node, r );
 	print("inserted: %s", inserted ? "true" : "false");
 	release_node( db, root_node );
-	
+
 	root_node = retrieve_node( db, db->header->root_node_id );
 	print( "after insert: root node id: %u (%p)", db->header->root_node_id, root_node );
 	check_tree_correctness (db, root_node );
@@ -345,7 +345,7 @@ bool database_put( database* db, board63 key ) {
 
 	print_index( db );
 	prints("done\n");
-	return inserted;		
+	return inserted;
 }
 
 // TODO(bug): find a good way to do this, and not chase bugs for hours.
@@ -357,10 +357,10 @@ bool database_store( database* db, board* b ) {
 	// the index knows if we already have this record,
 	// but in order to store it we need to have the offset in the table
 	// which we know as we can just keep track of that
-	
+
 	board63 board_key = encode_board( b );
 	print("key for this board: 0x%lx", board_key );
-	
+
 	record r = { .key = board_key, .value.board_data = 0xdeadbeef };
 
 	counters.key_inserts++;
@@ -372,7 +372,7 @@ bool database_store( database* db, board* b ) {
 	bool inserted = bpt_insert_or_update( db, root_node, r );
 	print("inserted: %s", inserted ? "true" : "false");
 	release_node( db, root_node );
-	
+
 	// tree might have grown, and since it grows upward *root might not point at the
 	// actual root anymore. But since all parent pointers are set we can traverse up
 	// to find the actual root
@@ -386,11 +386,11 @@ bool database_store( database* db, board* b ) {
 		root_node = up;
 	}
 	db->header->root_node_id = root_node->id;
-	
+
 	print( "after insert: root node id: %u (%p)", db->header->root_node_id, root_node );
 	check_tree_correctness (db, root_node );
 	release_node( db, root_node );
-	
+
 	// now write the data as a "row" to the table file
 
 	if( inserted ) {
@@ -407,7 +407,7 @@ bool database_store( database* db, board* b ) {
 	}
 
 	return inserted;
-	
+
 }
 
 /*
@@ -428,13 +428,13 @@ internal unsigned char binary_search( board63* keys, uint32 num_keys, board63 ta
 	if( keys == NULL ) {
 		return BINSEARCH_ERROR;
 	}
-	
+
 	// empty array, or insert location should be initial element
 	if( num_keys == 0 || target_key < keys[0] ) {
 		*key_index = 0;
 		return BINSEARCH_INSERT;
 	}
-	
+
 	uint32 span = num_keys;
 	uint32 mid = num_keys / 2;
 	uint32 large_half;
@@ -445,9 +445,9 @@ internal unsigned char binary_search( board63* keys, uint32 num_keys, board63 ta
 			*key_index = mid;
 			return BINSEARCH_FOUND;
 		}
-		
+
 		span = span/2; // half the range left over
-		large_half = span/2 + (span % 2);// being clever. But this is ceil 
+		large_half = span/2 + (span % 2);// being clever. But this is ceil
 
 		counters.key_compares++;
 		if( target_key < keys[mid] ) {
@@ -455,7 +455,7 @@ internal unsigned char binary_search( board63* keys, uint32 num_keys, board63 ta
 		} else {
 			mid += large_half;
 		}
-		
+
 	}
 
 	// target_key is not an element of keys, but we found the closest location
@@ -496,20 +496,20 @@ internal unsigned char binary_search( board63* keys, uint32 num_keys, board63 ta
 
 // TODO(bug): take db as param, put in node cache
 node* new_node( database* db ) {
-	
+
 	node* out = node_get_mem();
 	// node* out = (node*)malloc( sizeof(node) );
-	
+
 	out->id = ++db->header->node_count;
-	
+
 	out->parent_node_id = 0;
-	
+
 	out->num_keys = 0;
 	out->is_leaf = true;
 	out->is_dirty = true; // should start out dirty since it is guaranteed not to be on disk
-	
+
 	counters.node_creates++;
-	
+
 	// NOTE: Put the new new in the cache because it is likely to be used immediatky,
 	// but more importantly it may be retrieved before whatever calls new_node() calls release_node()
 	// which would mean it would end up in the cache with a refcount 0 and then be released again.
@@ -517,13 +517,13 @@ node* new_node( database* db ) {
 	// new_node() / release_node()
 	// retrieve_node() / release_node()
 	put_node_in_cache( db, out );
-	
+
 	print("created node ID: %u (%p) (cr: %llu/ld: %llu/fr: %llu)", out->id, out, counters.node_creates, counters.node_loads, counters.node_frees  );
 	return out;
 }
 
 void print_database_stats( database* db ) {
-	
+
 	double cache_memory_used = (double)(CACHE_SIZE * ( sizeof(node) + sizeof(entry*) + sizeof(entry) + sizeof(free_entry) ) ) / (double)megabyte(1);
 	printf("BPT ORDER: %d, Node size: %lu bytes, CACHE_SIZE: %lu (Cache max mem use: %.2f MB)\n", ORDER, sizeof(node), CACHE_SIZE, cache_memory_used);
 
@@ -562,20 +562,20 @@ void bpt_insert_node( database* db, node* n, board63 up_key, uint32 node_to_inse
 
 	assert( n->id != 0 );
 	check_tree_correctness( db, n );
-	
+
 	uint32 insert_location;
 	int bsearch_result = binary_search( n->keys, n->num_keys, up_key, &insert_location );
 	assert( bsearch_result == BINSEARCH_FOUND || bsearch_result == BINSEARCH_INSERT );
 	print("insert key 0x%lx at position %u, node at position %u", up_key, insert_location, insert_location+1);
-	
+
 	// move keys over (could be 0 if at end)
 	uint32 elements_moving_right = n->num_keys - insert_location;
 //	printf("Moving %zu elements\n", elements_moving_right);
-	
+
 	// move keys right and set the key in the open space
 	memmove( &n->keys[insert_location+1], &n->keys[insert_location], sizeof(board63)*elements_moving_right);
 	n->keys[insert_location] = up_key;
-	
+
 	// move pointers over (given that sibling is the right part of the split node,
 	// move 1 more than the keys)
 	memmove( &n->pointers[insert_location+2], &n->pointers[insert_location+1], sizeof(pointer)*elements_moving_right );
@@ -611,75 +611,75 @@ void bpt_split( database* db, node* n ) {
 
 	print("node %u: %s (%p)", n->id, (n->is_leaf ? "leaf" : "node"), n );
 	print_index( db ); // TODO(granularity): function to print starting from a specific node
-	/* 
+	/*
 	Create a sibling node
-	
+
 	2 cases: (1) the node is a leaf, (2) the node isn't a leaf
-	
+
 	(1) - Leaf node
-	
+
 		Imagine a btp with ORDER=4. This means we split when we have 4 keys: [ 1 2 3 4 ]
 		We split this into 2 nodes around key index 1 = [ 2 ]
-		Result:	
+		Result:
 					[ 2 ]
 			 [ 1 ]    [ 2 3 4 ]
 		This means key 2 is pushed up, and we still have key 2 in the sibling node since that's
 		where we store the associated value.
 		This means the split means copying 3 keys/values from the node to the sibling, and pushing key 2 up.
-	
+
 	(2) - Not a leaf node
-	
+
 		Example: [ 2 3 4 5 ]
 		But now these hold keys, and the values are pointers to nodes that hold the same keys (and the values).
-	
+
 		Initial situation after inserting 7:
 				[2]  [3]  [4]		    <-- keys + node pointers
 			[1]  [2]  [3]  [4 5 6 7] <-- keys + values
-	
+
 		The end structure should look like this:
-	
+
 							[3]						<-- keys + node pointers
 					[2]			[4] [5]			<-- keys + node pointers
 				[1]  [2]    [3]  [4]  [5 6 7]	<-- keys + values
-	
+
 		So first we split the leaf node [4 5 6 7] like before, and we end up with:
-	
+
 				[2]  [3]  [4]  [5]		   <-- keys + node pointers
 			[1]  [2]  [3]  [4]  [5 6 7]   <-- keys + values
-	
+
 		Now we need to split the node with keys + pointers, so call bpt_split() again.
-	
+
 		We need to push up key 3, but copy 2 keys: [4 5] to the sibling, and 3 node pointers: [3] [4] [5 6 7]
-		The reason is that we don't need an intermediary key 3 since the key+value of 3 are already in a 
+		The reason is that we don't need an intermediary key 3 since the key+value of 3 are already in a
 		leaf node at the bottom.
-	
+
 		Intermediate result:
-	
+
 			Node				Sibling
 			[2]			 [4]  [5]
 		[1]  [2]     [3]  [4]  [5 6 7]
-	
+
 		Now 2 more cases: (a) node above this level, (b) no node above this level
-	
+
 		(b) - No node above this level (it's easier)
-	
+
 		Create a new node with 1 key (3) and 2 node pointers to Node and Sibling
 		Set the parent pointers of Node and Sibling to point to the new root.
-	
+
 		(a) - Node above this level
-		
+
 		This node must already have a key and a pointer to Node (and the key in this example must be 1)
-		
+
 		Insert key 3 in the parent node (shifting others if needed)
 		Insert Sibling in the parent node (shifting others if needed)
-		
-		
+
+
 	So in all cases we need to create a sibling node and copy items over:
-	
+
 	is_leaf:
 			copy K keys: ORDER/2 + 1 (for even ORDER: half+1, for odd ORDER: the larger half)
 			copy N values (same as the number of keys)
-	
+
 	!is_leaf:
 			copy K keys: ORDER - ORDER/2 (for even ORDER: half, for odd ORDER: the larger half)
 			copy N pointers: K+1
@@ -693,15 +693,15 @@ void bpt_split( database* db, node* n ) {
 	uint32 offset = n->is_leaf ? SPLIT_KEY_INDEX : SPLIT_NODE_INDEX;
 	print("moving %u keys (%u nodes/values) right from offset %u (key = 0x%lx)", keys_moving_right, keys_moving_right+1, offset, n->keys[offset] );
 
-	node* sibling = new_node( db );	
+	node* sibling = new_node( db );
 	memcpy( &sibling->keys[0], &n->keys[offset], sizeof(board63)*keys_moving_right );
 	memcpy( &sibling->pointers[0], &n->pointers[offset], sizeof(pointer)*(keys_moving_right+1) );
-	
+
 	// housekeeping
 	sibling->parent_node_id = n->parent_node_id;
 	sibling->num_keys = keys_moving_right;
 	sibling->is_leaf = n->is_leaf; // if n was NOT a leaf, then sibling can't be either.
-	
+
 	// if the node had subnodes (!is_leaf) then the subnodes copied to the sibling need
 	// their parent pointer updated
 	// TODO(performance): keep the subnodes around so update parent pointer doesn't hit the disk
@@ -713,18 +713,18 @@ void bpt_split( database* db, node* n ) {
 			release_node( db, s );
 		}
 	}
-	
+
 	// when splitting a node a key and 2 nodes move up
 	n->num_keys = n->num_keys - keys_moving_right - (n->is_leaf ? 0 : 1);
 	n->is_dirty = true; // modified the num_keys (the rest is essentially garbage, but no point in clearing it)
-	
+
 #ifdef VERBOSE
 	print("created sibling node %u (%p)", sibling->id, sibling);
 	print_index_from( db, sibling->id );
 	print("node %u left over (%p)", n->id, n);
 	print_index_from( db, n->id );
 #endif
-	
+
 	// the key that moves up is the split key in the leaf node case, and otherwise
 	// the key we didn't propagate to the sibling node and didn't keep in the node
 	// which is the one we're splitting around... so in both cases this is the same.
@@ -759,13 +759,13 @@ void bpt_split( database* db, node* n ) {
 		// with a NkN. The parent is actually kkk, NNNN so finding where to insert the key
 		// is easy and obvious, and the node we can just add the sibling beside our current node
 		// (since in essence we represent the same data as before so must be adjacent)
-		
+
 		// now this is fairly doable, but it might lead to having to split the parent
 		// as well
 #ifdef VERBOSE
 		print("going to insert into parent node ID %u", n->parent_node_id);
 		print_index( db );
-#endif		
+#endif
 		counters.parent_inserts++;
 		// TODO(performance): node cache
 		node* parent = retrieve_node( db, n->parent_node_id );
@@ -776,7 +776,7 @@ void bpt_split( database* db, node* n ) {
 	check_tree_correctness (db, n );
 
 	release_node( db, sibling );
-	
+
 }
 
 /*
@@ -787,7 +787,7 @@ void bpt_split( database* db, node* n ) {
 bool bpt_insert_or_update( database* db, node* root, record r ) {
 
 	assert( root->id != 0 );
-	
+
 	counters.insert_calls++;
 	print("node %u - %p", root->id, root);
 
@@ -801,9 +801,9 @@ bool bpt_insert_or_update( database* db, node* root, record r ) {
 		int bsearch_result = binary_search( root->keys, root->num_keys, r.key, &insert_location);
 		assert( bsearch_result == BINSEARCH_FOUND || bsearch_result == BINSEARCH_INSERT );
 		print("Leaf node - insert location: %u", insert_location);
-		
+
 		root->is_dirty = true; // we're inserting something in this node
-		
+
 		k = insert_location;
 //		printf("Insertion location: keys[%d] = %d (atend = %d)\n", k, root->keys[k], k == root->num_keys );
 		// if we're not appending but inserting, ODKU (we can't check on value since we might be at the end
@@ -811,10 +811,10 @@ bool bpt_insert_or_update( database* db, node* root, record r ) {
 		if( k < root->num_keys && root->keys[k] == r.key ) {
 			print("Overwrite of keys[%u] = %lu (value %u to %u)", k, r.key, root->pointers[k].board_data, r.value.board_data );
 			root->pointers[k] = r.value;
-			
+
 			return false; // was not inserted but updated (or ignored)
 		}
-		
+
 		// now insert at k, but first shift everything after k right
 		memmove( &root->keys[k+1], &root->keys[k], sizeof(board63)*(root->num_keys - k) );
 		memmove( &root->pointers[k+1], &root->pointers[k], sizeof(pointer)*(root->num_keys - k) );
@@ -824,7 +824,7 @@ bool bpt_insert_or_update( database* db, node* root, record r ) {
 
 		root->num_keys++;
 
-		// split if full 
+		// split if full
 		// TODO(bug?): figure out when to save the root node, or maybe not at all?
 		if( root->num_keys == ORDER ) {
 			print("hit limit, have to split node %u (%p)", root->id, root);
@@ -862,7 +862,7 @@ bool bpt_insert_or_update( database* db, node* root, record r ) {
 	bool was_insert = bpt_insert_or_update( db, target, r );
 	print("inserted into child node (was_insert: %s)", ( was_insert ? "true" : "false") );
 	release_node( db, target );
-	
+
 	return was_insert;
 }
 
@@ -870,22 +870,22 @@ bool bpt_insert_or_update( database* db, node* root, record r ) {
 	Return the leaf node that should have key in it.
 */
 internal node* bpt_find_node( database* db, node* root, board63 key ) {
-	
+
 	assert( root->id != 0 );
-	
+
 	node* current = root;
-	
+
 	while( !current->is_leaf ) {
 
 		print("checking node %u", current->id);
-		
+
 		uint32 node_index;
 		switch( binary_search( current->keys, current->num_keys, key, &node_index) ) {
 			case BINSEARCH_FOUND:
 				node_index++; // if we hit the key, the correct node is to the right of that key
 				break; // needless break here
 			case BINSEARCH_INSERT:
-				// insert means we determined the target is to the left of this key (which is the correct node) 
+				// insert means we determined the target is to the left of this key (which is the correct node)
 				break;
 			case BINSEARCH_ERROR:
 			default:
@@ -896,7 +896,7 @@ internal node* bpt_find_node( database* db, node* root, board63 key ) {
 		// correctness checks
 		if( node_index == 0 ) { // target should be smaller than key 0
 			assert( key < current->keys[node_index] );
-		} else { // target should be equal/bigger than the key to the left of that node 
+		} else { // target should be equal/bigger than the key to the left of that node
 			assert( key >= current->keys[node_index-1] );
 		}
 
@@ -908,7 +908,7 @@ internal node* bpt_find_node( database* db, node* root, board63 key ) {
 		}
 		current = retrieve_node( db, next_node_id );
 	}
-	
+
 	print("returning node %u", current->id);
 	return current;
 }
@@ -917,7 +917,7 @@ internal node* bpt_find_node( database* db, node* root, board63 key ) {
 // TODO(performance): probably mmap() the file
 // TODO(performance): maybe avoid file locking? OSX doesn't come with __fsetlocking() though (maybe use open() to get O_EXLOCK ?)
 node* load_node_from_file( database* db, uint32 node_id ) {
-print("loading block %lu\n", node_id);	
+print("loading block %lu\n", node_id);
 	size_t node_block_bytes = sizeof( node );
 	off_t node_block_offset = file_offset_from_node( node_id );
 	print("nbo: %lu\n", node_block_offset);
@@ -927,11 +927,11 @@ print("loading block %lu\n", node_id);
 		perror("fseek()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	// TODO(bug): Feel this might cause hard ot find bugs. Maybe a check for filesize and error out on fread fail
 	// node* n = (node*) malloc( sizeof(node) );
 	node* n = node_get_mem();
-	
+
 	assert( n != NULL );
 	size_t objects_read = fread( n, node_block_bytes, 1, db->index_file );
 	if( objects_read != 1 ) {
@@ -940,7 +940,7 @@ print("loading block %lu\n", node_id);
 		printf("unable to load node %u\n", node_id);
 		exit( EXIT_FAILURE );
 	}
-	
+
 	assert( !n->is_dirty ); // flag should have been cleared when writing
 
 	// TODO(remove): just to keep a working thing
@@ -959,30 +959,30 @@ bool load_row_from_file( board63 b63, FILE* in, off_t offset, board* b ) {
 		perror("fseek()");
 		return false;
 	}
-	
+
 	char buf[ BOARD_SERIALIZATION_NUM_BYTES ];
 	size_t elements_read = fread( buf, sizeof(buf), 1, in );
 	assert( elements_read == 1 );
-	
-	
+
+
 	read_board_record_from_buf( b63, (char*)buf, 0, b );
 }
 #endif
 
 bool database_get( database* db, board63 key ) {
-	
+
 	print("loading root node ID %u", db->header->root_node_id );
 	node* root_node = retrieve_node( db, db->header->root_node_id );
 	record* r = bpt_get( db, root_node, key );
 	release_node( db, root_node );
-	
+
 	if( r == NULL ) {
 		return false;
 	}
 
 	return true;
 
-#if 0	
+#if 0
 	off_t offset = file_offset_from_row_index( r->value.board_data_index );
 	print("Board data offset: %llu", offset);
 
@@ -993,18 +993,18 @@ bool database_get( database* db, board63 key ) {
 record* bpt_get( database* db, node* root, board63 key ) {
 
 	assert( root->id != 0 );
-	
+
 	counters.get_calls++;
 	print("key 0x%lx", key);
 	node* dest_node = bpt_find_node( db, root, key );
 	print("Found correct node %u", dest_node->id);
 	//bpt_print( dest_node, 0 );
-	
+
 	if( dest_node == NULL ) {
 		fprintf( stderr, "No node found at all WTF\n");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	// now we have a leaf that *could* contain our key, but it's sorted
 	uint32 key_index;
 	if( BINSEARCH_FOUND != binary_search( dest_node->keys, dest_node->num_keys, key, &key_index ) ) {
@@ -1015,7 +1015,7 @@ record* bpt_get( database* db, node* root, board63 key ) {
 		return NULL;
 	}
 	print("Key index: %u", key_index);
-	
+
 	record* r = (record*)malloc( sizeof(record) );
 	if( r == NULL ) {
 		perror("malloc()");
@@ -1036,34 +1036,34 @@ record* bpt_get( database* db, node* root, board63 key ) {
 		prints("Key was in the root node, not releasing.");
 	}
 	return r;
-	
+
 }
 
 
 void print_index_from( database* db, uint32 start_node_id ) {
 	int print;
-#ifdef VERBOSE		
+#ifdef VERBOSE
 	print = 1;
 #else
 	print = 0;
 #endif
 	if (print) {
-	
+
 	node* start = retrieve_node( db, start_node_id );
 	if( start->is_leaf ) {
 		printf("+---------------------- LEAF NODE %u ------------------------------+\n", start->id);
 		bpt_print_leaf( start, 0 );
-		printf("+---------------------- END LEAF NODE %u --------------------------+\n", start->id);	
+		printf("+---------------------- END LEAF NODE %u --------------------------+\n", start->id);
 	} else {
 		printf("+---------------------- NODE %u ------------------------------+\n", start->id);
 		bpt_print( db, start, 0 );
-		printf("+---------------------- END NODE %u --------------------------+\n", start->id);	
+		printf("+---------------------- END NODE %u --------------------------+\n", start->id);
 	}
 	release_node( db, start );
 	}
 }
 
-void print_index( database* db ) {	
+void print_index( database* db ) {
 	print_index_from( db, db->header->root_node_id );
 }
 
@@ -1071,18 +1071,18 @@ void print_index( database* db ) {
 // NOTE(performance): this could be very slow, but I'm not sure that will ever be relevant
 size_t bpt_size( database* db, node* start ) {
 	counters.any++;
-	
+
 	if( start->is_leaf ) {
 		return start->num_keys;
 	}
-	
+
 	size_t count = 0;
 	for( size_t i=0; i<=start->num_keys; i++ ) { // 1 more pointer than keys
 		node* child = retrieve_node( db, start->pointers[i].child_node_id );
 		count += bpt_size( db, child );
-		release_node( db, child );		
+		release_node( db, child );
 	}
-	
+
 	return count;
 }
 

--- a/bplustree.h
+++ b/bplustree.h
@@ -63,9 +63,9 @@ typedef struct record {
 // node_id 0 is reserved to indicate NULL/empty/no parent
 // TODO: maybe we can put the is_leaf first so we can check for leaf nodes easily in the file (well, wecould use an offset., but still)
 typedef struct node {
-	
+
 	uint32 id;
-	
+
 	uint32 parent_node_id;
 
 	uint32 num_keys; // number of entries
@@ -106,7 +106,7 @@ Finding a free entry must then also be O(1), which is why there is a separate fr
 The cache entry holds a pointer to either a node or a free_entry.
 
 Operations:
-(1) Insert, space in the cache: 
+(1) Insert, space in the cache:
 	- hash the key
 	- create an entry
 	- set the node ptr of the entry
@@ -175,7 +175,7 @@ typedef struct entry {
 		node* to_node;
 		free_entry* to_free_entry;
 	} ptr;
-	
+
 	struct entry* next;
 	// TODO(space): maybe node id could be 32 bits? refcount certainly is and that would save 8 bytes
 	// maybe even some kind of size_t node_id:54, size_t refcount:10 kind of thing
@@ -219,10 +219,10 @@ typedef struct database {
 } database;
 
 typedef struct database_cursor {
-	
+
 	size_t current;
 	size_t num_records;
-	
+
 	// internal
 	uint64* data; // mmapped
 	node* current_node; // offset into data

--- a/bplustree_utils.c
+++ b/bplustree_utils.c
@@ -1,9 +1,9 @@
 
 internal void bpt_print_leaf( node* n, int indent ) {
-	
+
 	char ind[100] = "                               END";
 	ind[indent*2] = '\0';
-	
+
 	printf("%sL(%u)-[ ", ind, n->id);
 	for( size_t i=0; i<n->num_keys; i++ ) {
 		printf("0x%lx ", n->keys[i] );
@@ -17,14 +17,14 @@ internal inline void bpt_print( database* db, node* start, int indent ) {
 
 	char ind[100] = "                               END";
 	ind[indent*2] = '\0';
-	
+
 	if( start->is_leaf ) {
 		bpt_print_leaf( start, indent );
 		return;
 	}
 
 	printf("%sN(%u) (%p) keys: %u (parent id %u)\n", ind, start->id, (void *)start, start->num_keys, start->parent_node_id);
-		
+
 	// print every key/node
 	node* n;
 	for( uint32 i=0; i<start->num_keys; i++ ) {
@@ -34,14 +34,14 @@ internal inline void bpt_print( database* db, node* start, int indent ) {
 		if( n->is_leaf ) {
 			bpt_print_leaf( n, indent+1 );
 		} else {
-			bpt_print( db, n, indent+1 );			
+			bpt_print( db, n, indent+1 );
 		}
 		printf("%sK[%u]-[ 0x%lx ]\n", ind, i, start->keys[i] );
 		release_node( db, n );
-		
+
 	}
 	// print the last node
-	n = retrieve_node( db, start->pointers[start->num_keys].child_node_id  ); 
+	n = retrieve_node( db, start->pointers[start->num_keys].child_node_id  );
 	assert( n != NULL );
 	bpt_print( db, n, indent + 1 );
 	release_node( db, n );
@@ -49,11 +49,11 @@ internal inline void bpt_print( database* db, node* start, int indent ) {
 }
 
 internal inline board63 max_key( database* db, node* n ) {
-	
+
 	if( n->is_leaf ) {
 		return n->keys[ n->num_keys-1 ];
 	}
-	
+
 	node* last_node = retrieve_node( db, n->pointers[ n->num_keys ].child_node_id );
 	board63 out = max_key( db, last_node );
 	release_node( db, last_node );
@@ -61,33 +61,33 @@ internal inline board63 max_key( database* db, node* n ) {
 	return out;
 }
 
-#ifdef VERBOSE	
+#ifdef VERBOSE
 internal void check_tree_correctness( database* db, node* n ) {
 
 	print("Checking correctness of node %u", n->id );
-	
+
 	// for leaves, check if all keys are ascending
 	if( n->is_leaf ) {
-		
+
 		for(uint32 i=0; i<n->num_keys-1; i++ ) {
 			assert( n->keys[i] < n->keys[i+1]);
 		}
 		print("node %u OK", n->id);
 		return;
 	}
-	
+
 
 	for(uint32 i=0; i<n->num_keys; i++ ) {
 		// for every key, the max
-		node* temp = retrieve_node( db, n->pointers[i].child_node_id ); 
+		node* temp = retrieve_node( db, n->pointers[i].child_node_id );
 		board63 max = max_key( db, temp );
 		release_node( db, temp );
 		print("key[%u] = 0x%lx, max from left node = 0x%lx", i, n->keys[i], max );
 		assert( max < n->keys[i] );
 	}
-	
+
 	// check the final one
-	node* temp = retrieve_node( db, n->pointers[ n->num_keys ].child_node_id ); 
+	node* temp = retrieve_node( db, n->pointers[ n->num_keys ].child_node_id );
 	board63 max = max_key( db, temp );
 	release_node( db, temp );
 	print("key[%u] = 0x%lx, max from right node = 0x%lx", n->num_keys-1, n->keys[ n->num_keys-1], max );
@@ -96,4 +96,4 @@ internal void check_tree_correctness( database* db, node* n ) {
 }
 #else
 #define check_tree_correctness( db, n ) // nothing
-#endif	
+#endif

--- a/bpt_test.c
+++ b/bpt_test.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h> 
+#include <time.h>
 
 
 #include "base.h"
@@ -14,11 +14,11 @@
 
 
 internal void test_header( const char* title ) {
-	
+
 	char row[] = "#####################################################";
 	row[ strlen(title)+4 ] = '\0';
 	printf("\n%s\n# %s #\n%s\n", row, title, row);
-	
+
 }
 
 internal void test_dupes() {
@@ -45,40 +45,40 @@ internal void test_dupes() {
 		render( next, "Dupe board", false );
 		was_insert = database_store( db, next );
 		assert( !was_insert );
-		
+
 		free_board( current );
 		current = next;
-		
+
 		print_index( db );
 	}
-	
+
 	node* root_node = load_node_from_file( db, db->header->root_node_id );
 	assert( bpt_size( db, root_node ) == COUNT );
 	release_node( db, root_node );
 
 	assert( db->header->table_row_count == COUNT );
-	
+
 	free_board( current );
-	
+
 	print_database_stats( db );
-	
+
 	database_close( db );
-	
+
 }
 
 
 internal void test_store_cmdline_seq( char* seq ) {
-	
+
 	database_create( "test_store_cmdline_seq" );
 	database* db = database_open( "test_store_cmdline_seq", DATABASE_READ | DATABASE_WRITE );
-	
+
 	printf("Sequence: %s\n", seq);
 	char* element = strtok( seq, "," );
 
 	board* current = new_board();
-	
+
 	while( element != NULL ) {
-		
+
 		int col_index = atoi(element);
 		printf("\n>>>>> Insert Board with move in col %d\n", col_index );
 
@@ -99,22 +99,22 @@ internal void test_store_cmdline_seq( char* seq ) {
 		decode_board63( key, &retrieved );
 		render( &retrieved, "result from db_get", false);
 		assert( encode_board( &retrieved ) == key );
-		
-		
+
+
 		free_board( current );
 		current = next;
 
 		printf("<<<<< After insert\n" );
 		print_index( db );
 
-		
+
 		element = strtok( NULL, "," );
 	}
-	
+
 	free_board( current );
 
 	print_database_stats( db );
-	
+
 	database_close( db );
 }
 
@@ -124,14 +124,14 @@ int main(int argc, char** argv) {
 	map_squares_to_winlines();
 
 	printf("ORDER %d, SPLIT_KEY_INDEX %d\n", ORDER, SPLIT_KEY_INDEX );
-	
+
 	// run cmd line stuff OR all tests
 	if( argc == 2 ){
 		test_store_cmdline_seq( argv[1] );
 		exit( EXIT_SUCCESS );
 	}
-	
+
 	test_dupes();
-	
+
 	printf("Done\n");
 }

--- a/bruteforce_connect_four.c
+++ b/bruteforce_connect_four.c
@@ -22,7 +22,7 @@
 
 
 internal void print_stats( const char* directory ) {
-	
+
 	char genfilename[256];
 	printf("Node order: %d\tCache size: %lu\n", ORDER, CACHE_SIZE);
 	printf("Gen\tTotal\tUnique\twins W\twins B\tCPU time (s)\tCache hit %%\tfilesize (MB)\n");
@@ -39,7 +39,7 @@ internal void print_stats( const char* directory ) {
 		printf( "%d\t%lu\t%lu\t%lu\t%lu\t%f\t%f\t%.3f\n", g, gc->total_boards, gc->unique_boards, gc->wins_white, gc->wins_black, gc->cpu_time_used, 100.0*gc->cache_hit_ratio, (double)gc->database_size/(double)megabyte(1) );
 
 	}
-	
+
 }
 
 internal void display_progress( size_t current, size_t total ) {
@@ -58,31 +58,31 @@ internal void next_generation( const char* database_from, const char* database_t
 	database* from = database_open( database_from, DATABASE_READ );
 	database_create( database_to );
 	database* to = database_open( database_to, DATABASE_WRITE );
-		
+
 	// do all 7 moves in 1 drop, avoiding mallocing a brazillian new boards
 	board63 next_gen[7];
-	
+
 	// iterate over all boards in the db
 	struct database_cursor cursor;
 	database_init_cursor( from, &cursor );
-	
+
 	// gen next
 	gen_counter counters;
-	memset( &counters, 0, sizeof(gen_counter) );	
+	memset( &counters, 0, sizeof(gen_counter) );
 
 	// cpu timing
 	clock_t cpu_time_start = clock();
-	
+
 	while( cursor.current < cursor.num_records ) {
 		print("Retrieving record %lu", cursor.current);
 		display_progress( cursor.current, cursor.num_records );
-		
+
 		board63 current_board63 = database_get_record( &cursor );
-		
+
 		if( is_end_state( current_board63 ) ) {
 			continue;
 		}
-		
+
 		board current_board;
 		decode_board63( current_board63, &current_board );
 		// render( &current_board, "Multidrop", false);
@@ -113,24 +113,24 @@ internal void next_generation( const char* database_from, const char* database_t
 	counters.cpu_time_used = ((double)( clock() - cpu_time_start ) / CLOCKS_PER_SEC );
 	cache_stats cstats = get_database_cache_stats( to );
 	counters.cache_hit_ratio = cstats.hit_ratio;
-	
+
 	database_dispose_cursor( &cursor );
-	
+
 	print_database_stats( to );
-	
+
 	database_close( from );
 	database_close( to );
 
 	struct stat gstat;
 	char index_filename[256];
 	sprintf(index_filename, "%s.c4_index", database_to);
-	
+
 	int stat_result = stat( index_filename, &gstat);
 	assert( stat_result != -1 );
 	counters.database_size = (unsigned long)gstat.st_size;
-	
+
 	write_counter( &counters, "gencounter.gc" );
-	
+
 }
 
 /* getopt_long stores the option index here. */
@@ -150,7 +150,7 @@ int main( int argc, char** argv ) {
 	char* source = NULL;
 	char* destination = NULL;
 
-	int c;	
+	int c;
 
 	while( (c = getopt_long (argc, argv, "ts:d:r:", long_options, &option_index) ) != -1 ) {
 

--- a/bruteforce_connect_four.c
+++ b/bruteforce_connect_four.c
@@ -24,7 +24,7 @@
 internal void print_stats( const char* directory ) {
 
 	char genfilename[256];
-	printf("Node order: %d\tCache size: %lu\n", ORDER, CACHE_SIZE);
+	printf("Node order: %d\tCache size: %zu\n", ORDER, CACHE_SIZE);
 	printf("Gen\tTotal\tUnique\twins W\twins B\tCPU time (s)\tCache hit %%\tfilesize (MB)\n");
 	for( int g=1; g<=42; g++ ) { // just try all possible and break when done
 

--- a/counter.c
+++ b/counter.c
@@ -31,7 +31,7 @@ gen_counter* read_counter( const char* filename ) {
 		perror("fread()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	fclose( in );
 
 	return gc;
@@ -41,12 +41,12 @@ void write_counter( gen_counter* c, const char* filename ) {
 
 	FILE* out;
 	FOPEN_CHECK( out, filename, "wb" );
-	
+
 	size_t bytes_written = fwrite( c, 1, sizeof(gen_counter), out );
 	if( bytes_written != sizeof(gen_counter) ) {
 		perror("fwrite()");
 		exit( EXIT_FAILURE );
 	}
-	
+
 	fclose( out );
 }

--- a/db_utils.c
+++ b/db_utils.c
@@ -173,7 +173,7 @@ int main( int argc, char** argv  ) {
 
 	if( argc == 2 ) {
 		db = database_open( argv[1], DATABASE_READ );
-		printf("Nodes %u, Rows: %llu, Root Node ID: %u\n", db->header->node_count, db->header->table_row_count, db->header->root_node_id);
+		printf("Nodes %u, Rows: %llu, Root Node ID: %u\n", db->header->node_count, (unsigned long long)db->header->table_row_count, db->header->root_node_id);
 	}
 
 	do {

--- a/store_boards.c
+++ b/store_boards.c
@@ -22,16 +22,16 @@ int main( int argc, char** argv ) {
 	char* moves = NULL;
 	char* destination = NULL;
 
-	int c;	
+	int c;
 
 	while( (c = getopt_long (argc, argv, "c:d:", long_options, &option_index) ) != -1 ) {
 
 		switch( c ) {
 			case 'm':
-				moves = optarg;		
+				moves = optarg;
 				break;
 			case 'd':
-				destination = optarg;		
+				destination = optarg;
 				break;
 		}
 	}
@@ -49,7 +49,7 @@ int main( int argc, char** argv ) {
 		database_close( db );
 		exit( EXIT_SUCCESS );
 	}
-	 
+
 	board* next = NULL;
 	for( size_t i=0; i<strlen(moves); i++ ) {
 		int col_index = moves[i] - '0';
@@ -65,13 +65,13 @@ int main( int argc, char** argv ) {
 		free_board( current );
 		current = next;
 	}
-	
+
 	render( next, "Final Board", false );
 	free_board( next );
 	database_close( db );
-	
+
 	printf("Done.\n");
-	
+
 	return 0;
 }
 

--- a/utils.c
+++ b/utils.c
@@ -10,14 +10,14 @@
 #ifdef BUILD_32_BITS
 
 size_t hash( size_t i ) {
-	
+
 	size_t h = i;
 	h ^= h >> 16;
 	h *= 0x85ebca6b;
 	h ^= h >> 13;
 	h *= 0xc2b2ae35;
 	h ^= h >> 16;
-	
+
 	return h;
 }
 
@@ -53,7 +53,7 @@ size_t gcd(size_t m, size_t n) {
 }
 
 FILE* open_and_seek( const char* filename, const char* mode, off_t offset ) {
-	
+
 	FILE* f;
 	FOPEN_CHECK( f, filename, mode );
 
@@ -62,7 +62,7 @@ FILE* open_and_seek( const char* filename, const char* mode, off_t offset ) {
 		perror("fseek()");
 		return NULL;
 	}
-	
+
 	return f;
 }
 


### PR DESCRIPTION
Only little things. The Makefile.gcc is now the same as the clang version. Some warnings fixed, most were harmless, one potentially real. Trailing whitespace seemed like ti was going to make for a weird diff, thus I started with a simple "make tidy" makefile target which simply kills trailing whitespace. I have not parameterized the run.fish, thus a bit of tinkering by-hand is still needed when using gcc.